### PR TITLE
Anderweitige Nutztung bedingt erlaubt

### DIFF
--- a/betriebsanweisung_reflow-ofen.tex
+++ b/betriebsanweisung_reflow-ofen.tex
@@ -84,10 +84,11 @@
 
 \begin{itemize}
 	\setlength{\itemsep}{-3pt}
-	\item Der Reflowofen ist nach Einweisung nur für Lötvorgänge geeignet (z.\,B. SMD-Bauteilen auf Platine)
+	\item Der Reflowofen ist nur für Lötvorgänge geeignet (z.\,B. SMD-Bauteilen auf Platine)
 	\item Anderweitige Benutzung muss auf jeden Fall mit einem Betreuer abgeklaert werden
-	\item Zubereitung von Lebensmitteln ist absolut verboten
-	\item Der Controller darf nicht für andere Geräte verwendet werden.
+	\item Lebensmittel und Materialien, bei denen Brand-, Rauch- und Gestankgefahr herrscht, sind absolut verboten
+	\item Alle Teile im Ofen (Sensor, Platinen) müssen entfernt werden, wenn nicht gereflowed wird
+	\item Der Controller darf nicht für andere Geräte verwendet werden
 \end{itemize}
 	\item Der Reflowcontroller darf von Benutzern nicht verstellt werden. Dies ist ausschließlich Betreuern mit ausreichender Kenntnis der Bedienungsanleitung erlaubt. Wurden Änderungen vorgenommen, sind diese nach Benutzung wieder auf die Standardeinstellungen zurückzusetzen.
 	\item Während des Lötvorgangs entstehen gesundheitsschädliche Dämpfe, deshalb für vollen Durchzug sorgen, also \textbf{Fenster und Dachfenster aufmachen! Wenn nicht für einen vollen Durchzug gesorgt werden kann (z.B. im Winter, Starkregen) darf der Ofen nicht verwendet werden.}

--- a/betriebsanweisung_reflow-ofen.tex
+++ b/betriebsanweisung_reflow-ofen.tex
@@ -84,8 +84,9 @@
 
 \begin{itemize}
 	\setlength{\itemsep}{-3pt}
-	\item Der Reflowofen ist nur für Lötvorgänge geeignet (z.\,B. von SMD-Bauteilen auf eine Platine)
-	\item Anderweitige Benutzung ist verboten, insbesondere die Zubereitung von Lebensmitteln.
+	\item Der Reflowofen ist nach Einweisung nur für Lötvorgänge geeignet (z.\,B. SMD-Bauteilen auf Platine)
+	\item Anderweitige Benutzung muss auf jeden Fall mit einem Betreuer abgeklaert werden
+	\item Zubereitung von Lebensmitteln ist absolut verboten
 	\item Der Controller darf nicht für andere Geräte verwendet werden.
 \end{itemize}
 	\item Der Reflowcontroller darf von Benutzern nicht verstellt werden. Dies ist ausschließlich Betreuern mit ausreichender Kenntnis der Bedienungsanleitung erlaubt. Wurden Änderungen vorgenommen, sind diese nach Benutzung wieder auf die Standardeinstellungen zurückzusetzen.


### PR DESCRIPTION
Hallo,

am Treffen vom 11.1.2016 wurde ja besprochen, dass man den Ofen schon für was Anderes her nehmen kann, aber halt nir bedingt und nach ordentlicher Absprache. Ich hoffe, ich hab das treffend formuliert. Wenn du ( @Virtex7 ) meinst, dass es so passt, kannst du es mergen.
